### PR TITLE
minor tweaks to get it to compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GO_PKGS      := $(shell go list ./... | grep -v "/vendor/")
 GO_FILES     := $(shell ls ./*.go)
 BUILD_DIR    := ./bin/
 COVERAGE_DIR := ./coverage/
-VALIDATE_DEPS = github.com/golang/lint/golint
+VALIDATE_DEPS = golang.org/x/lint/golint
 DEPS          = github.com/kardianos/govendor
 TEST_DEPS     = github.com/axw/gocov/gocov github.com/AlekSi/gocov-xml
 

--- a/cli.go
+++ b/cli.go
@@ -44,7 +44,7 @@ func main() {
 	case "insert":
 		cli := client.NewInsertClient(*insightsKey, *accountID)
 		if cli == nil {
-			log.Fatal("Failed to create a %s client", cmd)
+			log.Fatal("Failed to create a cli client")
 		}
 		if len(*insightsURL) > 0 {
 			cli.UseCustomURL(*insightsURL)

--- a/coverage/README.md
+++ b/coverage/README.md
@@ -1,0 +1,1 @@
+coverage directory required


### PR DESCRIPTION
The location of the linter changed.
Also `vet` complained about the `%s` in the fatal log message in `cli.go`
And the `coverage` directory needs to be present to compile
