### PR TITLE
Modified generateQueryURL to prevent data race conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ clean:
 
 tools: check-version
 	@echo "=== $(PROJECT_NAME) === [ tools            ]: Installing tools required by the project..."
-	@$(GO) get $(GOTOOLS)
+	go get -u $(GOTOOLS)
 	@$(GOMETALINTER) --install
 
 tools-update: check-version

--- a/client/README.md
+++ b/client/README.md
@@ -1,6 +1,6 @@
 # client
 --
-    import "github.com/newrelic/go-insights/client"
+    import "github.com/bpeckNR/go-insights/client"
 
 
 ## Usage

--- a/client/README.md
+++ b/client/README.md
@@ -1,6 +1,6 @@
 # client
 --
-    import "github.com/bpeckNR/go-insights/client"
+    import "github.com/newrelic/go-insights/client"
 
 
 ## Usage

--- a/client/query.go
+++ b/client/query.go
@@ -63,7 +63,9 @@ func (c *QueryClient) Query(nrqlQuery string, response interface{}) (err error) 
 	}
 
 	err = c.queryRequest(nrqlQuery, response)
-
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -75,7 +77,7 @@ func (c *QueryClient) queryRequest(nrqlQuery string, queryResult interface{}) (e
 
 	queryURL, err := c.generateQueryURL(nrqlQuery)
 	if err != nil {
-		return errors.New("Unable to generate query URL")
+		return err
 	}
 
 	if queryResult == nil {
@@ -120,21 +122,18 @@ func (c *QueryClient) queryRequest(nrqlQuery string, queryResult interface{}) (e
 // generateQueryURL URL encodes the NRQL
 func (c *QueryClient) generateQueryURL(nrqlQuery string) (string, error) {
 	if len(nrqlQuery) < minValidNRQLLength {
+		fmt.Println("Query was too short")
 		return "", fmt.Errorf("NRQL query is too short [%s]", nrqlQuery)
 	}
 
 	// Use a new set of Values to sanitize the query string
 	urlQuery := url.Values{}
 	urlQuery.Set("nrql", nrqlQuery)
-	queryString := urlQuery.Encode() // Seems odd, but directly out of the docs for net/url
+	queryString := urlQuery.Encode()
 
 	queryURL := c.URL.String() + "?" + queryString
 
-	if len(queryURL) < 1 {
-		return "", fmt.Errorf("Query string can not be empty")
-	}
-
-	log.Debugf("query url is: %s", queryURL)
+	c.Logger.Debugf("query url is: %s", queryURL)
 
 	return queryURL, nil
 }

--- a/client/query_unit_test.go
+++ b/client/query_unit_test.go
@@ -47,9 +47,10 @@ func TestQueryClientValidate(t *testing.T) {
 
 func TestGenerateQueryURL(t *testing.T) {
 	client := NewQueryClient(testKey, testID)
-
-	client.generateQueryURL(testNRQLQuery)
-	assert.Equal(t, testNRQLQueryEncoded, client.URL.RawQuery, "generateQueryURL should of set client.URL.RawQuery")
+	testURL := client.URL.String() + "?" + testNRQLQueryEncoded
+	query, err := client.generateQueryURL(testNRQLQuery)
+	assert.NoError(t, err)
+	assert.Equal(t, testURL, query, "generateQueryURL did not properly encode URL")
 }
 
 func TestQueryClientQuery(t *testing.T) {
@@ -101,7 +102,8 @@ func TestQueryClientQueryRequest(t *testing.T) {
 
 	// Empty NRQL
 	res = &QueryResponse{}
-	err = client.queryRequest(res)
+	query := ""
+	err = client.queryRequest(query, res)
 	assert.Error(t, err, "Empty NRQL query should fail")
 }
 
@@ -118,9 +120,9 @@ func TestQueryClientQueryRequest_decodeFailure(t *testing.T) {
 	assert.Equal(t, ts.URL, client.URL.String())
 
 	// NIL result pointer
-	err = client.generateQueryURL(testNRQLQuery)
+	query, err := client.generateQueryURL(testNRQLQuery)
 	assert.NoError(t, err)
-	err = client.queryRequest(nil)
+	err = client.queryRequest(query, nil)
 	assert.Error(t, err, "Empty result pointer should fail")
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -53,7 +53,7 @@
 			"revisionTime": "2017-09-30T17:45:11Z"
 		},
 		{
-			"checksumSHA1": "tY+5thYxjKDUQyQXYcBqogmMS5U=",
+			"checksumSHA1": "uggjqMBFNJd11oNco2kbkAT641w=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "314a259e304ff91bd6985da2a7149bbf91237993",
 			"revisionTime": "2017-07-19T03:44:26Z"
@@ -71,5 +71,5 @@
 			"revisionTime": "2015-09-17T02:59:07Z"
 		}
 	],
-	"rootPath": "github.com/newrelic/go-insights"
+	"rootPath": "github.com/bpeckNR/go-insights"
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -71,5 +71,5 @@
 			"revisionTime": "2015-09-17T02:59:07Z"
 		}
 	],
-	"rootPath": "github.com/bpeckNR/go-insights"
+	"rootPath": "github.com/newrelic/go-insights"
 }


### PR DESCRIPTION
The previous method of storing the rawQuery as part of the client caused data race conditions when a shared client was used to execute multiple concurrent queries.  I changed this to use a variable to hold the query instead, which resolved the data race.  

