### PR TITLE
enhance log messages when getting an error from insights

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,5 +45,7 @@ linters:
   disable:
     - dupl
     - gochecknoglobals
+    - godox
     - interfacer
+    - wsl
 

--- a/client/insert.go
+++ b/client/insert.go
@@ -267,9 +267,15 @@ func (c *InsertClient) grabAndConsumeEvents(count int, eventBuf [][]byte) {
 		// only send the slice that we pulled into the buffer
 		for tries := 0; tries < c.RetryCount; tries++ {
 			if sendErr := c.sendEvents(saved[0:count]); sendErr != nil {
-				c.Logger.Errorf("Failed to send events [%d/%d]: %v", tries, c.RetryCount, sendErr)
-				atomic.AddInt64(&c.Statistics.InsightsRetryCount, 1)
-				time.Sleep(c.RetryWait)
+				if tries+1 >= c.RetryCount {
+					//failed last retry
+					c.Logger.Errorf("Failed to send insights events [%d/%d] times. Retry limit reached -- Abandoning data. Error: %v",
+						tries+1, c.RetryCount, sendErr)
+				} else {
+					c.Logger.Errorf("Failed to send insights events [%d/%d]. Will retry. Error: %v", tries+1, c.RetryCount, sendErr)
+					atomic.AddInt64(&c.Statistics.InsightsRetryCount, 1)
+					time.Sleep(c.RetryWait)
+				}
 			} else {
 				break
 			}


### PR DESCRIPTION
Made log messages a little clearer when getting errors from insights. Now the messages are clearer about whether the batch will be retried or abandoned. Also, the prior logic used the loop index so it showed attempts 0, 1, and 2 for a standard 3 tries. Consequently, 2/3 was the last try so it was not overly clear that data was being lost.

Old messages were similar to:
Failed to send insights events [0/3]: Insights Post: : bad response from Insights: 403
Failed to send insights events [1/3]: Insights Post: : bad response from Insights: 403
Failed to send insights events [2/3]: Insights Post: : bad response from Insights: 403

New Messages:
Failed to send insights events [1/3]. Will retry. Error: Insights Post: : bad response from Insights: 403
Failed to send insights events [3/3] times. Retry limit reached -- Abandoning data. Error: Insights Post: : bad response from Insights: 403
Failed to send insights events [2/3]. Will retry. Error: Insights Post: : bad response from Insights: 403