### PR TITLE
add EnqueueEventContext to help prevent potential of blocking

### DIFF
--- a/client/insert_unit_test.go
+++ b/client/insert_unit_test.go
@@ -3,6 +3,7 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -298,6 +299,36 @@ func TestNewInsertClientEnqueueEvent_good(t *testing.T) {
 	}{1}
 	err := client.EnqueueEvent(event)
 	assert.NoError(t, err)
+}
+
+func TestNewInsertClientEnqueueEventContext_good(t *testing.T) {
+	client := NewInsertClient(testKey, testID)
+
+	assert.NotNil(t, client)
+	client.eventQueue = make(chan []byte, 1)
+
+	event := struct {
+		Test int
+	}{1}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	err := client.EnqueueEventContext(ctx, event)
+	assert.NoError(t, err)
+}
+
+func TestNewInsertClientEnqueueEventContext_timeout(t *testing.T) {
+	client := NewInsertClient(testKey, testID)
+
+	assert.NotNil(t, client)
+	client.eventQueue = make(chan []byte)
+
+	event := struct {
+		Test int
+	}{1}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	err := client.EnqueueEventContext(ctx, event)
+	assert.Error(t, err)
 }
 
 func TestNewInsertClientFlush_good(t *testing.T) {


### PR DESCRIPTION
Though it hopefully wouldn't be reality long term in production, there is
the potential that for very high volume and too few workers the standard EnqueueEvent
call could block when putting and even on the channel for the workers to
pick up. This allows the user of the client to decide how long they would
like to block before giving up trying to put on the channel.