### PR TITLE
Add TotalResult to QueryResponse

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -203,9 +203,10 @@ QueryMetadata used to decode the JSON response metadata from Insights
 
 ```go
 type QueryResponse struct {
-	Results  []map[string]interface{} `json:"results"`
-	Facets   []map[string]interface{} `json:"facets"`
-	Metadata QueryMetadata            `json:"metadata"`
+	Results     []map[string]interface{} `json:"results"`
+	Facets      []map[string]interface{} `json:"facets"`
+	TotalResult map[string]interface{}   `json:"totalResult"`
+	Metadata    QueryMetadata            `json:"metadata"`
 }
 ```
 

--- a/client/types.go
+++ b/client/types.go
@@ -102,9 +102,10 @@ type QueryClient struct {
 
 // QueryResponse used to decode the JSON response from Insights
 type QueryResponse struct {
-	Results  []map[string]interface{} `json:"results"`
-	Facets   []map[string]interface{} `json:"facets"`
-	Metadata QueryMetadata            `json:"metadata"`
+	Results     []map[string]interface{} `json:"results"`
+	Facets      []map[string]interface{} `json:"facets"`
+	TotalResult map[string]interface{}   `json:"totalResults"`
+	Metadata    QueryMetadata            `json:"metadata"`
 }
 
 // QueryMetadata used to decode the JSON response metadata from Insights

--- a/client/types.go
+++ b/client/types.go
@@ -104,7 +104,7 @@ type QueryClient struct {
 type QueryResponse struct {
 	Results     []map[string]interface{} `json:"results"`
 	Facets      []map[string]interface{} `json:"facets"`
-	TotalResult map[string]interface{}   `json:"totalResults"`
+	TotalResult map[string]interface{}   `json:"totalResult"`
 	Metadata    QueryMetadata            `json:"metadata"`
 }
 


### PR DESCRIPTION
When I search in NewRelic Insights with query like this:
`SELECT count(*) FROM TransactionError WHERE appName = 'myApp' FACET aggregateFacet  LIMIT 1`
I get this response:
```
{
   "facets":[
      {
         "name":"Transaction/Example",
         "results":[
            {
               "count":36
            }
         ]
      }
   ],
   "totalResult":{
      "results":[
         {
            "count":111
         }
      ]
   },
   "unknownGroup":{
      "results":[
         {
            "count":75
         }
      ]
   },
   "metadata":{
      "eventTypes":[
         "TransactionError"
      ],
      "eventType":"TransactionError",
      "openEnded":true,
      "beginTime":"2020-04-16T07:20:08Z",
      "endTime":"2020-04-16T08:20:08Z",
      "beginTimeMillis":1587021608289,
      "endTimeMillis":1587025208289,
      "rawSince":"60 MINUTES AGO",
      "rawUntil":"NOW",
      "rawCompareWith":"",
      "guid":"",
      "routerGuid":"",
      "messages":[

      ],
      "facet":"aggregateFacet",
      "offset":0,
      "limit":1,
      "contents":{
         "messages":[

         ],
         "contents":[
            {
               "function":"count",
               "simple":true
            }
         ]
      }
   }
}
```
I would like to use totalResult data in my project.